### PR TITLE
Make VirusTotal connector pyinstaller-able

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,12 +22,6 @@ var/
 .installed.cfg
 *.egg
 
-# PyInstaller
-#  Usually these files are written by a python script from a template
-#  before PyInstaller builds the exe, so as to inject date/other infos into it.
-*.manifest
-*.spec
-
 # Installer logs
 pip-log.txt
 pip-delete-this-directory.txt

--- a/bit9PlatformAPI/examples/VirusTotalConnector.py
+++ b/bit9PlatformAPI/examples/VirusTotalConnector.py
@@ -1,0 +1,66 @@
+from common import bit9api
+from connectors import VirusTotal
+from ConfigParser import RawConfigParser
+import sys
+import logging
+
+log = logging.getLogger(__name__)
+
+
+def main():
+    inifile = RawConfigParser({
+        "bit9_server_url": "https://localhost",
+        "bit9_server_sslverify": False,
+        "bit9_server_token": None,
+        "vt_api_key": None,
+        "retrieve_files": True,
+        "upload_binaries_to_vt": False,
+        "download_location": None,
+        "connector_name": "VirusTotal",
+    })
+    inifile.read("virustotal.ini")
+
+    config = {}
+
+    config["bit9_server_url"] = inifile.get("bridge", "bit9_server_url")
+    config["bit9_server_token"] = inifile.get("bridge", "bit9_server_token")
+    config["bit9_server_sslverify"] = inifile.getboolean("bridge", "bit9_server_sslverify")
+    config["vt_api_key"] = inifile.get("bridge", "vt_api_key")
+    config["retrieve_files"] = inifile.getboolean("bridge", "retrieve_files")
+    config["download_location"] = inifile.get("bridge", "download_location")
+    config["connector_name"] = inifile.get("bridge", "connector_name")
+    config["upload_binaries_to_vt"] = inifile.getboolean("bridge", "upload_binaries_to_vt")
+
+    if not config["vt_api_key"]:
+        log.fatal("Cannot start without a valid VirusTotal API key, exiting")
+        return 1
+
+    if not config["bit9_server_token"]:
+        log.fatal("Cannot start without a valid Bit9 server API token, exiting")
+        return 1
+
+    log.info("Configuration:")
+    for k,v in config.iteritems():
+        log.info("    %-20s: %s" % (k,v))
+
+    bit9 = bit9api.bit9Api(
+        config["bit9_server_url"],
+        token=config["bit9_server_token"],
+        ssl_verify=config["bit9_server_sslverify"]
+    )
+
+    vt = VirusTotal.virusTotalConnector(
+        bit9,
+        vt_token=config["vt_api_key"],
+        allow_uploads=config["upload_binaries_to_vt"],  # Allow VT connector to upload binary files to VirusTotal
+        connector_name=config["connector_name"],
+        download_location=config["download_location"]
+    )
+
+    log.info("Starting VirusTotal processing loop")
+    vt.start()
+
+
+if __name__ == '__main__':
+    sys.exit(main())
+

--- a/bit9PlatformAPI/examples/VirusTotalConnector.py
+++ b/bit9PlatformAPI/examples/VirusTotalConnector.py
@@ -1,13 +1,15 @@
 import logging
-logging.basicConfig(format='%(asctime)s %(levelname)s:%(message)s', level=logging.DEBUG)
-
 from common import bit9api
 from connectors import VirusTotal
 from ConfigParser import RawConfigParser
 import sys
 import requests
 
+# logging
+logging.basicConfig(format='%(asctime)s %(levelname)s:%(message)s', level=logging.DEBUG)
 log = logging.getLogger(__name__)
+logging.getLogger("requests").setLevel(logging.WARNING)
+logging.getLogger("urllib3").setLevel(logging.WARNING)
 
 
 def main():
@@ -20,6 +22,7 @@ def main():
         "upload_binaries_to_vt": False,
         "download_location": None,
         "connector_name": "VirusTotal",
+        "log_file": None,
     })
     inifile.read("virustotal.ini")
 
@@ -33,6 +36,14 @@ def main():
     config["download_location"] = inifile.get("bridge", "download_location")
     config["connector_name"] = inifile.get("bridge", "connector_name")
     config["upload_binaries_to_vt"] = inifile.getboolean("bridge", "upload_binaries_to_vt")
+
+    log_file = inifile.get("bridge", "log_file")
+    if log_file:
+        file_handler = logging.FileHandler(log_file)
+        formatter = logging.Formatter('%(asctime)s %(levelname)s:%(message)s')
+        file_handler.setFormatter(formatter)
+        file_handler.setLevel(logging.DEBUG)
+        log.addHandler(file_handler)
 
     if not config["vt_api_key"]:
         log.fatal("Cannot start without a valid VirusTotal API key, exiting")

--- a/bit9PlatformAPI/examples/VirusTotalConnector.py
+++ b/bit9PlatformAPI/examples/VirusTotalConnector.py
@@ -8,6 +8,8 @@ log = logging.getLogger(__name__)
 
 
 def main():
+    logging.basicConfig(format='%(asctime)s %(levelname)s:%(message)s')
+
     inifile = RawConfigParser({
         "bit9_server_url": "https://localhost",
         "bit9_server_sslverify": False,

--- a/bit9PlatformAPI/examples/VirusTotalConnector.py
+++ b/bit9PlatformAPI/examples/VirusTotalConnector.py
@@ -1,15 +1,16 @@
+import logging
+logging.basicConfig(format='%(asctime)s %(levelname)s:%(message)s', level=logging.DEBUG)
+
 from common import bit9api
 from connectors import VirusTotal
 from ConfigParser import RawConfigParser
 import sys
-import logging
+import requests
 
 log = logging.getLogger(__name__)
 
 
 def main():
-    logging.basicConfig(format='%(asctime)s %(levelname)s:%(message)s')
-
     inifile = RawConfigParser({
         "bit9_server_url": "https://localhost",
         "bit9_server_sslverify": False,
@@ -40,6 +41,9 @@ def main():
     if not config["bit9_server_token"]:
         log.fatal("Cannot start without a valid Bit9 server API token, exiting")
         return 1
+
+    if not config["bit9_server_sslverify"]:
+        requests.packages.urllib3.disable_warnings()
 
     log.info("Configuration:")
     for k,v in config.iteritems():

--- a/bit9PlatformAPI/examples/common/bit9api.py
+++ b/bit9PlatformAPI/examples/common/bit9api.py
@@ -19,6 +19,10 @@ POSSIBILITY OF SUCH DAMAGES.
 
 import json
 import requests
+import logging
+
+log = logging.getLogger(__name__)
+
 
 class bit9Api(object):
     def __init__(self, server, ssl_verify=True, token=None):
@@ -58,9 +62,9 @@ class bit9Api(object):
 
     def __check_result(self, r):
         if 400 <= r.status_code < 500:
-            print('%s Client Error: %s, %s' % (r.status_code, r.reason, r.text))
+            log.error('%s Client Error: %s, %s' % (r.status_code, r.reason, r.text))
         elif 500 <= r.status_code < 600:
-            print('%s Server Error: %s, %s' % (r.status_code, r.reason, r.text))
+            log.error('%s Server Error: %s, %s' % (r.status_code, r.reason, r.text))
         elif r.text != '':
             return r.json()
         return False

--- a/bit9PlatformAPI/examples/connectors/VirusTotal.py
+++ b/bit9PlatformAPI/examples/connectors/VirusTotal.py
@@ -48,10 +48,10 @@ import zipfile
 import tempfile
 import shutil
 
-# Import our common bit9api (assumed to live in common folder, sibling to current folder)
-commonPath = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'common')
-sys.path.append(commonPath)
-import bit9api
+import logging
+
+log = logging.getLogger(__name__)
+
 
 # -------------------------------------------------------------------------------------------------
 # VT connector class. Initialization where keys are specified is done at the bottom of the script
@@ -106,7 +106,7 @@ class virusTotalConnector(object):
                 for i in self.bit9.retrieve("v1/pendingAnalysis", url_params="connectorId=" + connectorId):
                     self.processOneAnalysisRequest(i)
             except Exception as e:
-                print("\n*** Exception: %s. Will try again in %d seconds." % (str(e), self.polling_frequency))
+                log.exception("Error during processing. Will try again in %d seconds." % (self.polling_frequency,))
             # Sleep N seconds, and then all over again
             time.sleep(self.polling_frequency)
 
@@ -115,7 +115,7 @@ class virusTotalConnector(object):
         # Unregister our connector
         r = self.bit9.search('v1/connector', ['name:'+self.connector_name])
         if len(r)>0:
-            print("Unregistering connector %s and deleting all its data" % self.connector_name)
+            log.info("Unregistering connector %s and deleting all its data" % self.connector_name)
             self.bit9.delete('v1/connector', r[0])
 
     def uploadFileToVT(self, pa):
@@ -144,6 +144,7 @@ class virusTotalConnector(object):
             pa['analysisError'] = 'Received error when attempting to unzip file from Bit9: %s' % str(e)
             # Update Bit9 status for this file
             self.bit9.update('v1/pendingAnalysis', pa)
+            log.exception("Could not unzip file from Bit9 for analysis of %s" % pa)
             return scanId
 
         outfp.seek(0)
@@ -155,6 +156,7 @@ class virusTotalConnector(object):
             if r.status_code == 200:
                 scanId = r.json()['scan_id']
         except:
+            log.exception("Could not send file %s to VirusTotal" % (pa,))
             isError = True
         finally:
             outfp.close()
@@ -183,16 +185,16 @@ class virusTotalConnector(object):
         positivesPerc = 100 * scanResults.get('positives') / scanResults.get('total')
         if positivesPerc > 50:
             notification['analysisResult'] = 3  # ...malicious
-            notification['severity'] = 'critical';
-            notification['type'] = 'malicious_file';
+            notification['severity'] = 'critical'
+            notification['type'] = 'malicious_file'
         elif positivesPerc > 0:
             notification['analysisResult'] = 2  # ...could be malicious
-            notification['severity'] = 'high';
-            notification['type'] = 'potential_risk_file';
+            notification['severity'] = 'high'
+            notification['type'] = 'potential_risk_file'
         else:
             notification['analysisResult'] = 1  # clean!
-            notification['severity'] = 'low';
-            notification['type'] = 'clean_file';
+            notification['severity'] = 'low'
+            notification['type'] = 'clean_file'
         notification['externalUrl'] = scanResults.get('permalink')
 
         # Enumerate scan results that have detected the issue and build our
@@ -214,7 +216,8 @@ class virusTotalConnector(object):
                 n += 1
         # Send notification
         self.bit9.create("v1/notification", notification)
-        print("VT analysis for fileAnalysis %d completed. VT result is %d%% malware (%s). Reporting status: %s" % (fileAnalysisId, positivesPerc, notification['malwareName'], notification['type']))
+        log.info("VT analysis for fileAnalysis %d completed. VT result is %d%% malware (%s). Reporting status: %s"
+                 % (fileAnalysisId, positivesPerc, notification['malwareName'], notification['type']))
 
     def processOneAnalysisRequest(self, pa):
         # Use md5 hash if we have one. If not, use Sha256
@@ -222,7 +225,6 @@ class virusTotalConnector(object):
         if fileHash == '':
             fileHash = pa['sha256'].strip()
 
-        lastAttempt = None
         scanId = None
         # Check our cache if we already sent this file for scan
         if fileHash in self.scheduledScans.keys():
@@ -240,14 +242,16 @@ class virusTotalConnector(object):
         r.raise_for_status()
         if r.status_code == 204:
             # no results from VT because rate limit was reached. We will try again later.
+            log.info("VirusTotal API rate limit reached, will try again later")
             return
 
+        scanId = None
         scanResults = r.json()
         # Check if we got results...
         if scanResults.get('positives') is not None:
             # Yes, VT has them. Report results and we are done with the file
+            log.info("%s: VirusTotal has a result ready, reporting to Bit9" % fileHash)
             self.reportResultToBit9(pa['id'], scanResults)
-            scanId =  None
         elif scanResults.get('scan_id') is not None:
             # VT already knows about the file, but scan is not complete. We got scanId for future reference
             # Let's remember that and try again in 1 hour (per VT best practices)
@@ -255,40 +259,54 @@ class virusTotalConnector(object):
         elif not self.allow_uploads:
             # Uploads are not allowed. Cancel the analysis
             pa['analysisStatus'] = 5 # (status: Cancelled)
+            log.info("%s: VirusTotal has no information and we aren't allowed to upload it. Cancelling the analysis request.")
             self.bit9.update('v1/pendingAnalysis', pa)
         elif pa['uploaded'] == 1:
             # We have file and now we will upload it to VT
+            log.info("%s: VirusTotal has no information on this hash. Uploading the file")
             scanId = self.uploadFileToVT(pa)
         else:
             # if we end here, it means that VT doesn't have file, and Bit9 hasn't uploaded it yet from the agent
             # we will come back again when we reach this file next time around
-            scanId = None
+            log.info("%s: VirusTotal has no information on this hash. Waiting for Bit9 agent to upload it.")
+            pass
 
-        if scanId is not None:
+        if scanId:
             # Remember scanId since VT wants use to use it for future references to the file
             # We will try again in 1 hour (per VT best practices)
-            self.scheduledScans[fileHash] = {'scanId': scanId, 'nextCheck': datetime.datetime.now()
-                                                                      + datetime.timedelta(0, 3600)}
+            next_check = datetime.datetime.now() + datetime.timedelta(0, 3600)
+            self.scheduledScans[fileHash] = {'scanId': scanId, 'nextCheck': next_check}
+            log.info("%s: Waiting for analysis to complete. Will check back after %s." % (fileHash,
+                                                                                          next_check.strftime("%Y-%m-%d %H:%M:%S")))
 
-# -------------------------------------------------------------------------------------------------
-# Main body of the script
+if __name__ == '__main__':
+    # -------------------------------------------------------------------------------------------------
+    # Main body of the script
 
-bit9 = bit9api.bit9Api(
-    "https://localhost",  # Replace with actual Bit9 server URL
-    token="<enter your Bit9 API token here>",  # Replace with actual Bit9 user token for VT integration
-    ssl_verify=False  # Don't validate server's SSL certificate. Set to True unless using self-signed cert on IIS
-)
+    try:
+        import bit9api
+    except ImportError:
+        # Import our common bit9api (assumed to live in common folder, sibling to current folder)
+        commonPath = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'common')
+        sys.path.append(commonPath)
+        import bit9api
 
-vtConnector = virusTotalConnector(
-    bit9,
-    vt_token='<enter your VT API key here>',  # Replace with your VT key
-    allow_uploads=True,  # Allow VT connector to upload binary files to VirusTotal
-    connector_name='VirusTotal',
-    download_location=r'c:\test'  # Replace with actual local file location. If not set,
-                                  # script will try to access shared folder where this file resides
-                                  # Note that you do not want to end your path with a backslash. ie. use
-                                  # r'c:\test' *not* r'c:\test\'.
-)
+    bit9 = bit9api.bit9Api(
+        "https://localhost",  # Replace with actual Bit9 server URL
+        token="<enter your Bit9 API token here>",  # Replace with actual Bit9 user token for VT integration
+        ssl_verify=False  # Don't validate server's SSL certificate. Set to True unless using self-signed cert on IIS
+    )
 
-print("\n*** VT script starting")
-vtConnector.start()
+    vtConnector = virusTotalConnector(
+        bit9,
+        vt_token='<enter your VT API key here>',  # Replace with your VT key
+        allow_uploads=True,  # Allow VT connector to upload binary files to VirusTotal
+        connector_name='VirusTotal',
+        download_location=r'c:\test'  # Replace with actual local file location. If not set,
+                                      # script will try to access shared folder where this file resides
+                                      # Note that you do not want to end your path with a backslash. ie. use
+                                      # r'c:\test' *not* r'c:\test\'.
+    )
+
+    print("\n*** VT script starting")
+    vtConnector.start()

--- a/bit9PlatformAPI/examples/connectors/VirusTotal.py
+++ b/bit9PlatformAPI/examples/connectors/VirusTotal.py
@@ -50,8 +50,6 @@ import shutil
 
 import logging
 
-log = logging.getLogger(__name__)
-
 
 # -------------------------------------------------------------------------------------------------
 # VT connector class. Initialization where keys are specified is done at the bottom of the script
@@ -99,7 +97,7 @@ class virusTotalConnector(object):
                             'connectorVersion': '1.0', 'canAnalyze': 'true', 'analysisEnabled': 'true'})
 
         if not r:
-            log.fatal("Could not create connector on the Bit9 server")
+            log.fatal("Could not create connector on the Bit9 server. Are the bit9 server URL and API token correct?")
             return
 
         connectorId = str(r['id'])
@@ -295,6 +293,13 @@ if __name__ == '__main__':
         commonPath = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'common')
         sys.path.append(commonPath)
         import bit9api
+
+    logging.basicConfig(format='%(asctime)s %(levelname)s:%(message)s', level=logging.DEBUG)
+    log = logging.getLogger(__name__)
+    logging.getLogger("requests").setLevel(logging.WARNING)
+    logging.getLogger("urllib3").setLevel(logging.WARNING)
+
+    requests.packages.urllib3.disable_warnings()
 
     bit9 = bit9api.bit9Api(
         "https://localhost",  # Replace with actual Bit9 server URL

--- a/bit9PlatformAPI/examples/connectors/VirusTotal.py
+++ b/bit9PlatformAPI/examples/connectors/VirusTotal.py
@@ -97,6 +97,11 @@ class virusTotalConnector(object):
         # Register or update our connector (can be done multiple times - will be treated as update on subsequent times)
         r = self.bit9.create('v1/connector', {'name': self.connector_name, 'analysisName': self.connector_name,
                             'connectorVersion': '1.0', 'canAnalyze': 'true', 'analysisEnabled': 'true'})
+
+        if not r:
+            log.fatal("Could not create connector on the Bit9 server")
+            return
+
         connectorId = str(r['id'])
 
         # Loop forever (until killed)

--- a/bit9PlatformAPI/examples/connectors/VirusTotal.py
+++ b/bit9PlatformAPI/examples/connectors/VirusTotal.py
@@ -259,16 +259,16 @@ class virusTotalConnector(object):
         elif not self.allow_uploads:
             # Uploads are not allowed. Cancel the analysis
             pa['analysisStatus'] = 5 # (status: Cancelled)
-            log.info("%s: VirusTotal has no information and we aren't allowed to upload it. Cancelling the analysis request.")
+            log.info("%s: VirusTotal has no information and we aren't allowed to upload it. Cancelling the analysis request." % fileHash)
             self.bit9.update('v1/pendingAnalysis', pa)
         elif pa['uploaded'] == 1:
             # We have file and now we will upload it to VT
-            log.info("%s: VirusTotal has no information on this hash. Uploading the file")
+            log.info("%s: VirusTotal has no information on this hash. Uploading the file" % fileHash)
             scanId = self.uploadFileToVT(pa)
         else:
             # if we end here, it means that VT doesn't have file, and Bit9 hasn't uploaded it yet from the agent
             # we will come back again when we reach this file next time around
-            log.info("%s: VirusTotal has no information on this hash. Waiting for Bit9 agent to upload it.")
+            log.info("%s: VirusTotal has no information on this hash. Waiting for Bit9 agent to upload it." % fileHash)
             pass
 
         if scanId:

--- a/bit9PlatformAPI/examples/virustotal.ini.example
+++ b/bit9PlatformAPI/examples/virustotal.ini.example
@@ -7,3 +7,6 @@ retrieve_files=True
 upload_binaries_to_vt=True
 download_location=c:\test
 connector_name=VirusTotal
+
+; uncomment to save logs to a file
+; log_file=c:\virustotal.log

--- a/bit9PlatformAPI/examples/virustotal.ini.example
+++ b/bit9PlatformAPI/examples/virustotal.ini.example
@@ -1,0 +1,9 @@
+[bridge]
+bit9_server_url=https://localhost
+bit9_server_sslverify=False
+bit9_server_token=xxxx
+vt_api_key=xxxx
+retrieve_files=True
+upload_binaries_to_vt=True
+download_location=c:\test
+connector_name=VirusTotal


### PR DESCRIPTION
Allows us to create a self-contained EXE for the connector removing the need for a separate Python installation on the server
