### PR TITLE
Fixed URL to bit9.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # bit9platform
 
 This folder contains documentation and examples related to the Bit9 Platform API.
-If you want to learn more about Bit9 + Carbon Black, please visit [www.bit9.com](www.bit9.com)
+If you want to learn more about Bit9 + Carbon Black, please visit [www.bit9.com](https://www.bit9.com)


### PR DESCRIPTION
PR fixes link which currently resolves to: https://github.com/carbonblack/bit9platform/blob/master/www.bit9.com
