### PR TITLE
changed to https

### DIFF
--- a/bit9PlatformAPI/examples/common/bit9api.py
+++ b/bit9PlatformAPI/examples/common/bit9api.py
@@ -33,7 +33,7 @@ class bit9Api(object):
                 token - this is token for API interface provided by Bit9 administrator
         """
 
-        if not server.startswith("http"): 
+        if not server.startswith("https"): 
             raise TypeError("Server must be URL: e.g, https://bit9server.local")
 
         if token is None: 


### PR DESCRIPTION
Changed URL verification to https instead of http because I spent 30 minutes chasing my tail because I was using http instead of https in the URL.  Just a simple way to save some frustration!
